### PR TITLE
fix: type annotations and import order in utils and tests

### DIFF
--- a/discord/utils/public.py
+++ b/discord/utils/public.py
@@ -542,7 +542,7 @@ def find(predicate: Callable[[T], Any], seq: Iterable[T]) -> T | None:
     return None
 
 
-with importlib.resources.files(__package__).joinpath("../emojis.json").open(encoding="utf-8") as f:
+with importlib.resources.files(__package__).joinpath("../emojis.json").open(encoding="utf-8") as f:  # pyright: ignore[reportArgumentType] # __package__ will always be discord.utils
     EMOJIS_MAP = json.load(f)
 
 UNICODE_EMOJIS = set(EMOJIS_MAP.values())

--- a/tests/test_find_util.py
+++ b/tests/test_find_util.py
@@ -26,9 +26,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterable, Iterator
 from typing import Literal, TypeVar
-from typing_extensions import TypeIs
 
 import pytest
+from typing_extensions import TypeIs
+
 from discord.utils import find
 
 T = TypeVar("T")
@@ -62,7 +63,7 @@ def equals_30(x: int) -> TypeIs[Literal[30]]:
     return x == 30
 
 
-def is_none_pred(x: object) -> TypeIs[Literal[None]]:
+def is_none_pred(x: object) -> TypeIs[None]:
     return x is None
 
 

--- a/tests/test_format_dt.py
+++ b/tests/test_format_dt.py
@@ -24,8 +24,10 @@ DEALINGS IN THE SOFTWARE.
 
 import datetime
 import random
+
 import pytest
-from discord.utils.public import format_dt, TimestampStyle
+
+from discord.utils.public import TimestampStyle, format_dt
 
 # Fix seed so that time tests are reproducible
 random.seed(42)

--- a/tests/test_markdown_utils.py
+++ b/tests/test_markdown_utils.py
@@ -24,8 +24,8 @@ DEALINGS IN THE SOFTWARE.
 
 from discord.utils import (
     escape_mentions,
-    raw_mentions,
     raw_channel_mentions,
+    raw_mentions,
     raw_role_mentions,
 )
 

--- a/tests/test_snowflake_datetime.py
+++ b/tests/test_snowflake_datetime.py
@@ -23,6 +23,7 @@ DEALINGS IN THE SOFTWARE.
 """
 
 import datetime
+
 import pytest
 
 from discord.utils import (
@@ -78,5 +79,5 @@ def test_snowflake_time_roundtrip_realistic(dt: datetime.datetime, _expected_ms:
 
 
 def test_generate_snowflake_invalid_mode() -> None:
-    with pytest.raises(ValueError, match="Invalid mode 'nope'. Must be 'realistic' or 'boundary'"):
+    with pytest.raises(ValueError, match=r"Invalid mode 'nope'. Must be 'realistic' or 'boundary'"):
         generate_snowflake(datetime.datetime.now(tz=UTC), mode="nope")  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
Corrected type annotation for is_none_pred in test_find_util.py and adjusted import order for consistency in several test files. Added a pyright ignore comment in public.py to suppress a false positive type check. Minor regex fix in test_snowflake_datetime.py for ValueError match.

## Summary

<!-- What is this pull request for? Does it fix any issues? -->

## Information

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed).
- [ ] This PR is **not** a code change (e.g. documentation, README, typehinting,
      examples, ...).

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] I have searched the open pull requests for duplicates.
- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] If `type: ignore` comments were used, a comment is also left explaining why.
- [ ] I have updated the changelog to include these changes.
